### PR TITLE
Add example for Windows 2019 AD on Azure

### DIFF
--- a/azure/win2019-ad/README.md
+++ b/azure/win2019-ad/README.md
@@ -1,0 +1,36 @@
+# Deploy Windows Server 2019 Domain Controller on Azure
+
+This example Terraform configuration deploys a Windows Server 2019 VM and
+initializes it as an Active Directory Domain Controller. Two test users
+`test1` and `test2` are created automatically.
+
+## Requirements
+
+- [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html)
+  1.0 or later
+- AzureRM provider 2.24.0 or later
+
+## Usage
+
+1. Copy `terraform.tfvars.example` to `terraform.tfvars` and update the
+   variable values as needed.
+2. Initialize Terraform:
+
+   ```sh
+   terraform init
+   ```
+3. Review the plan and apply:
+
+   ```sh
+   terraform apply
+   ```
+4. After testing, destroy the environment:
+
+   ```sh
+   terraform destroy
+   ```
+
+## Outputs
+
+After a successful deployment the public IP address of the domain controller and
+the administrator credentials are displayed.

--- a/azure/win2019-ad/main.tf
+++ b/azure/win2019-ad/main.tf
@@ -1,0 +1,97 @@
+resource "azurerm_resource_group" "rg" {
+  name     = var.resource_group_name
+  location = var.location
+}
+
+resource "azurerm_virtual_network" "vnet" {
+  name                = "ad-vnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+}
+
+resource "azurerm_subnet" "subnet" {
+  name                 = "ad-subnet"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_network_security_group" "nsg" {
+  name                = "ad-nsg"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  security_rule {
+    name                       = "rdp"
+    priority                   = 1001
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "3389"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+}
+
+resource "azurerm_subnet_network_security_group_association" "subnet" {
+  subnet_id                 = azurerm_subnet.subnet.id
+  network_security_group_id = azurerm_network_security_group.nsg.id
+}
+
+resource "azurerm_public_ip" "ip" {
+  name                = "ad-ip"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method   = "Dynamic"
+}
+
+resource "azurerm_network_interface" "nic" {
+  name                = "ad-nic"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.subnet.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.ip.id
+  }
+}
+
+resource "azurerm_windows_virtual_machine" "dc" {
+  name                = "windc2019"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+  size                = var.vm_size
+  admin_username      = var.admin_username
+  admin_password      = var.admin_password
+  network_interface_ids = [azurerm_network_interface.nic.id]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2019-Datacenter"
+    version   = "latest"
+  }
+
+  provision_vm_agent = true
+}
+
+resource "azurerm_virtual_machine_extension" "setup" {
+  name                 = "adsetup"
+  virtual_machine_id   = azurerm_windows_virtual_machine.dc.id
+  publisher            = "Microsoft.Compute"
+  type                 = "CustomScriptExtension"
+  type_handler_version = "1.9"
+
+  settings = jsonencode({
+    commandToExecute = "powershell -ExecutionPolicy Unrestricted -File setup-ad.ps1 -DomainName ${var.domain_name} -SafePassword ${var.admin_password} -UserPassword ${var.admin_password}"
+  })
+}

--- a/azure/win2019-ad/output.tf
+++ b/azure/win2019-ad/output.tf
@@ -1,0 +1,12 @@
+output "public_ip" {
+  value = azurerm_public_ip.ip.ip_address
+}
+
+output "username" {
+  value = var.admin_username
+}
+
+output "password" {
+  value = var.admin_password
+  sensitive = true
+}

--- a/azure/win2019-ad/provider.tf
+++ b/azure/win2019-ad/provider.tf
@@ -1,0 +1,8 @@
+provider "azurerm" {
+  features {}
+
+  subscription_id = var.subscription_id
+  client_id       = var.client_id
+  client_secret   = var.client_secret
+  tenant_id       = var.tenant_id
+}

--- a/azure/win2019-ad/setup-ad.ps1
+++ b/azure/win2019-ad/setup-ad.ps1
@@ -1,0 +1,16 @@
+param(
+    [string]$DomainName,
+    [string]$SafePassword,
+    [string]$UserPassword
+)
+
+$secpasswd = ConvertTo-SecureString $SafePassword -AsPlainText -Force
+Install-WindowsFeature AD-Domain-Services -IncludeManagementTools
+Install-ADDSForest -DomainName $DomainName -SafeModeAdministratorPassword $secpasswd -Force
+
+# Wait for AD DS to finish configuring
+Start-Sleep -Seconds 60
+
+Import-Module ActiveDirectory
+New-ADUser -Name "test1" -AccountPassword (ConvertTo-SecureString $UserPassword -AsPlainText -Force) -Enabled $true
+New-ADUser -Name "test2" -AccountPassword (ConvertTo-SecureString $UserPassword -AsPlainText -Force) -Enabled $true

--- a/azure/win2019-ad/terraform.tfvars.example
+++ b/azure/win2019-ad/terraform.tfvars.example
@@ -1,0 +1,10 @@
+subscription_id  = "<subscription_id>"
+client_id        = "<client_id>"
+client_secret    = "<client_secret>"
+tenant_id        = "<tenant_id>"
+
+location          = "eastus"
+resource_group_name = "ADTestRG"
+admin_username    = "azureuser"
+admin_password    = "P@ssw0rd1234!"
+domain_name       = "example.com"

--- a/azure/win2019-ad/variables.tf
+++ b/azure/win2019-ad/variables.tf
@@ -1,0 +1,35 @@
+variable "subscription_id" {}
+variable "client_id" {}
+variable "client_secret" {}
+variable "tenant_id" {}
+
+variable "location" {
+  type    = string
+  default = "eastus"
+}
+
+variable "resource_group_name" {
+  type    = string
+  default = "ADTestRG"
+}
+
+variable "admin_username" {
+  type    = string
+  default = "azureuser"
+}
+
+variable "admin_password" {
+  type      = string
+  default   = "P@ssw0rd1234!"
+  sensitive = true
+}
+
+variable "domain_name" {
+  type    = string
+  default = "example.com"
+}
+
+variable "vm_size" {
+  type    = string
+  default = "Standard_B2ms"
+}


### PR DESCRIPTION
## Summary
- add terraform example to deploy a Windows Server 2019 domain controller on Azure
- create two test users automatically

## Testing
- `terraform init -backend=false`
- `terraform validate`

------
https://chatgpt.com/codex/tasks/task_e_68489e85b93c8330bdf903740cfd2447